### PR TITLE
Exception Handling Code vereinfachen

### DIFF
--- a/src/ch/mtrail/tibrv/playground/Debug.java
+++ b/src/ch/mtrail/tibrv/playground/Debug.java
@@ -32,7 +32,6 @@ public class Debug {
 		 * (envVars.get(var).equals(javaLibPath)) { System.out.println(var); } }
 		 */
 
-		System.out.flush();
 	}
 
 }

--- a/src/ch/mtrail/tibrv/playground/ErrorLogger.java
+++ b/src/ch/mtrail/tibrv/playground/ErrorLogger.java
@@ -16,7 +16,6 @@ public class ErrorLogger implements TibrvMsgCallback {
 	public void onMsg(final TibrvListener listener, final TibrvMsg msg) {
 		System.err.println("#FEHLER# " + (new Date()).toString() + ": subject=" + msg.getSendSubject() + ", reply="
 				+ msg.getReplySubject() + ", message=" + msg.toString());
-		System.err.flush();
 
 		msg.dispose();
 	}

--- a/src/ch/mtrail/tibrv/playground/Listen.java
+++ b/src/ch/mtrail/tibrv/playground/Listen.java
@@ -13,28 +13,23 @@ import com.tibco.tibrv.TibrvMsgCallback;
 
 public class Listen extends Abstract implements TibrvMsgCallback {
 
-	public Listen(final String service, final String network, final String daemon, final List<String> subjects) {
+	public Listen(final String service, final String network, final String daemon, final List<String> subjects)
+			throws TibrvException {
 		super(service, network, daemon);
 
 		for (final String subject : subjects) {
 			// create listener using default queue
-			try {
-				/**
-				 * TibrvListener( TibrvQueue queue, TibrvMsgCallback callback,
-				 * TibrvTransport transport, java.lang.String subject,
-				 * java.lang.Object closure)
-				 */
-				new TibrvListener(Tibrv.defaultQueue(), this, transport, subject, null);
-				System.out.println("Listening on: " + subject);
-			} catch (final TibrvException e) {
-				System.err.println("Failed to create listener:");
-				e.printStackTrace();
-				System.exit(1);
-			}
+			/**
+			 * TibrvListener( TibrvQueue queue, TibrvMsgCallback callback,
+			 * TibrvTransport transport, java.lang.String subject,
+			 * java.lang.Object closure)
+			 */
+			new TibrvListener(Tibrv.defaultQueue(), this, transport, subject, null);
+			System.out.println("Listening on: " + subject);
 		}
 	}
 
-	public void dispatch() {
+	public void dispatch() throws TibrvException, InterruptedException {
 		dispatch(Tibrv.defaultQueue());
 	}
 
@@ -42,14 +37,13 @@ public class Listen extends Abstract implements TibrvMsgCallback {
 	public void onMsg(final TibrvListener listener, final TibrvMsg msg) {
 		System.out.println((new Date()).toString() + ": subject=" + msg.getSendSubject() + ", reply="
 				+ msg.getReplySubject() + ", message=" + msg.toString());
-		System.out.flush();
 
 		if (performDispose) {
 			msg.dispose();
 		}
 	}
 
-	public static void main(final String args[]) {
+	public static void main(final String args[]) throws Exception {
 		final ArgParser argParser = new ArgParser("TibRvListen");
 		argParser.setOptionalParameter("service", "network", "daemon");
 		argParser.setRequiredArg("subject");
@@ -58,18 +52,13 @@ public class Listen extends Abstract implements TibrvMsgCallback {
 		argParser.parse(args);
 
 		final List<String> subjects = new ArrayList<>();
-		try {
-			subjects.add(argParser.getArgument("subject"));
+		subjects.add(argParser.getArgument("subject"));
 
-			for (int i = 1; i <= 3; i++) {
-				final String addSubject = argParser.getArgument("addtional-subject" + i);
-				if (Objects.nonNull(addSubject)) {
-					subjects.add(addSubject);
-				}
+		for (int i = 1; i <= 3; i++) {
+			final String addSubject = argParser.getArgument("addtional-subject" + i);
+			if (Objects.nonNull(addSubject)) {
+				subjects.add(addSubject);
 			}
-		} catch (final Exception e) {
-			e.printStackTrace();
-			System.exit(-1);
 		}
 
 		final Listen listen = new Listen(//

--- a/src/ch/mtrail/tibrv/playground/ListenCM.java
+++ b/src/ch/mtrail/tibrv/playground/ListenCM.java
@@ -1,7 +1,7 @@
 package ch.mtrail.tibrv.playground;
 
+import java.io.IOException;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
@@ -21,29 +21,22 @@ public class ListenCM extends Abstract implements TibrvMsgCallback {
 	private TibrvCmListener cmListener = null;
 	private TibrvCmTransport cmTransport = null;
 
-	public ListenCM(final String service, final String network, final String daemon, final String subject) {
+	public ListenCM(final String service, final String network, final String daemon, final String subject)
+			throws TibrvException, IOException {
 		super(service, network, daemon);
-		
-		try {
-			cmname = "MyProgrammAndTheTaskItDoesIdentification__ListenCM_" + InetAddress.getLocalHost().getHostName();
-		} catch (final UnknownHostException e) {
-			handleFatalError(e);
-		}
 
-		try {
-			cmTransport = new TibrvCmTransport(transport, cmname, true);
+		cmname = "MyProgrammAndTheTaskItDoesIdentification__ListenCM_" + InetAddress.getLocalHost().getHostName();
 
-			cmListener = new TibrvCmListener(Tibrv.defaultQueue(), this, cmTransport, subject, null);
-			System.out.println("Listening on: " + subject);
+		cmTransport = new TibrvCmTransport(transport, cmname, true);
 
-			// Set explicit confirmation
-			cmListener.setExplicitConfirm();
-		} catch (final TibrvException e) {
-			handleFatalError(e);
-		}
+		cmListener = new TibrvCmListener(Tibrv.defaultQueue(), this, cmTransport, subject, null);
+		System.out.println("Listening on: " + subject);
+
+		// Set explicit confirmation
+		cmListener.setExplicitConfirm();
 	}
 
-	public void dispatch() {
+	public void dispatch() throws TibrvException, InterruptedException {
 		dispatch(Tibrv.defaultQueue());
 	}
 
@@ -52,7 +45,6 @@ public class ListenCM extends Abstract implements TibrvMsgCallback {
 		try {
 			System.out.println((new Date()).toString() + ": subject=" + msg.getSendSubject() + ", reply="
 					+ msg.getReplySubject() + ", message=" + msg.toString());
-			System.out.flush();
 
 			// Report we are confirming message
 			final long seqno = TibrvCmMsg.getSequence(msg);
@@ -76,7 +68,7 @@ public class ListenCM extends Abstract implements TibrvMsgCallback {
 		}
 	}
 
-	public static void main(final String args[]) {
+	public static void main(final String args[]) throws Exception {
 		// Debug.diplayEnvInfo();
 
 		final ArgParser argParser = new ArgParser("TibRvListenCM");

--- a/src/ch/mtrail/tibrv/playground/ListenDQ_RCS.java
+++ b/src/ch/mtrail/tibrv/playground/ListenDQ_RCS.java
@@ -28,21 +28,17 @@ public class ListenDQ_RCS extends Abstract {
 	private final static int threads = 5;
 	private TibrvCmQueueTransport dq;
 
-	public ListenDQ_RCS(final String service, final String network, final String daemon, final String subject) {
+	public ListenDQ_RCS(final String service, final String network, final String daemon, final String subject)
+			throws TibrvException {
 		super(service, network, daemon);
 
-		try {
-			queue = new TibrvQueue();
+		queue = new TibrvQueue();
 
-			dq = new TibrvCmQueueTransport(transport, dqGroupName);
-			dq.setWorkerTasks(rv_threads);
+		dq = new TibrvCmQueueTransport(transport, dqGroupName);
+		dq.setWorkerTasks(rv_threads);
 
-			new TibrvCmListener(queue, new RvDispatcher(syncQueue), dq, subject, null);
-			System.out.println("Listening on: " + subject);
-
-		} catch (final TibrvException e) {
-			handleFatalError(e);
-		}
+		new TibrvCmListener(queue, new RvDispatcher(syncQueue), dq, subject, null);
+		System.out.println("Listening on: " + subject);
 
 		// Init Thread to take msg from TbiRv and put them into syncQueue
 		// Will block if no one is polling the queue
@@ -59,17 +55,12 @@ public class ListenDQ_RCS extends Abstract {
 		}
 	}
 
-	public void printDebugInfo() {
+	public void printDebugInfo() throws TibrvException {
 		while (true) {
-			try {
 				System.out.println(
 						"QueueLength: " + queue.getCount() + " DQueueLength: " + dq.getUnassignedMessageCount());
-				System.out.flush();
 
 				LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(10));
-			} catch (final Exception e) {
-				e.printStackTrace();
-			}
 		}
 	}
 
@@ -90,7 +81,7 @@ public class ListenDQ_RCS extends Abstract {
 		}
 	}
 
-	public static void main(final String args[]) {
+	public static void main(final String args[]) throws Exception {
 		// Debug.diplayEnvInfo();
 
 		final ArgParser argParser = new ArgParser("TibRvListenFT");
@@ -122,7 +113,6 @@ public class ListenDQ_RCS extends Abstract {
 				System.out.println((new Date()).toString() + " " + Thread.currentThread().getName() + " TAKE  " //
 						+ "subject=" + msg.getSendSubject() + ", message=" + msg.toString() + ", seqno="
 						+ TibrvCmMsg.getSequence(msg));
-				System.out.flush();
 
 				syncQueue.put(msg);
 
@@ -164,14 +154,12 @@ public class ListenDQ_RCS extends Abstract {
 			System.out.println((new Date()).toString() + " " + Thread.currentThread().getName() + " START " //
 					+ "subject=" + msg.getSendSubject() + ", message=" + msg.toString() + ", seqno="
 					+ TibrvCmMsg.getSequence(msg));
-			System.out.flush();
 
 			LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(2));
 
 			msg.dispose();
 
 			System.out.println((new Date()).toString() + " " + Thread.currentThread().getName() + " FINISHED");
-			System.out.flush();
 		}
 
 		public void setRun(final boolean run) {

--- a/src/ch/mtrail/tibrv/playground/ListenFT.java
+++ b/src/ch/mtrail/tibrv/playground/ListenFT.java
@@ -18,16 +18,12 @@ public class ListenFT extends Abstract implements TibrvMsgCallback {
 	// Wenn man dir nichts anderes sagt, bist du PASIVE
 	private int ftStatus = TibrvFtMember.DEACTIVATE;
 
-	public ListenFT(final String service, final String network, final String daemon, final String subject) {
+	public ListenFT(final String service, final String network, final String daemon, final String subject) throws TibrvException {
 		super(service, network, daemon);
 		
 		// create listener using default queue
-		try {
-			new TibrvListener(Tibrv.defaultQueue(), this, transport, subject, null);
-			System.err.println("Listening on: " + subject);
-		} catch (final TibrvException e) {
-			handleFatalError(e);
-		}
+		new TibrvListener(Tibrv.defaultQueue(), this, transport, subject, null);
+		System.err.println("Listening on: " + subject);
 
 		// FaultTolerance
 		final TibrvFtMemberCallback callback = new TibrvFtMemberCallback() {
@@ -35,7 +31,7 @@ public class ListenFT extends Abstract implements TibrvMsgCallback {
 			public void onFtAction(final TibrvFtMember member, final String groupName, final int action) {
 				ftStatus = action;
 				System.err.println(System.currentTimeMillis() + " " + groupName + " -> " + //
-						getFtStatus(action) + " [" + action + "]");
+				getFtStatus(action) + " [" + action + "]");
 			}
 		};
 
@@ -65,18 +61,14 @@ public class ListenFT extends Abstract implements TibrvMsgCallback {
 		 *   Object closure 
 		 * )
 		 */
-		try {
-			final int defaultWeight = 50;
-			final int activePrcocesses = 2;
-			ftMember = new TibrvFtMember(Tibrv.defaultQueue(), callback, transport, ftGroupName, defaultWeight, activePrcocesses, //
-					0.5, 0, 1.0, null);
-		} catch (final TibrvException e) {
-			System.err.println("Failed to create FT member:");
-			handleFatalError(e);
-		}
+		final int defaultWeight = 50;
+		final int activePrcocesses = 2;
+		ftMember = new TibrvFtMember(Tibrv.defaultQueue(), callback, transport, ftGroupName, defaultWeight,
+				activePrcocesses, //
+				0.5, 0, 1.0, null);
 	}
 
-	public void dispatch() {
+	public void dispatch() throws TibrvException, InterruptedException {
 		dispatch(Tibrv.defaultQueue());
 	}
 
@@ -84,7 +76,6 @@ public class ListenFT extends Abstract implements TibrvMsgCallback {
 	public void onMsg(final TibrvListener listener, final TibrvMsg msg) {
 		System.out.println((new Date()).toString() + " " + getFtStatus(ftStatus) + "(" + ftMember.getWeight() + "): " //
 				+ "subject=" + msg.getSendSubject() + ", message=" + msg.toString());
-		System.out.flush();
 
 		msg.dispose();
 	}
@@ -104,17 +95,12 @@ public class ListenFT extends Abstract implements TibrvMsgCallback {
 	}
 
 	@Override
-	protected void userHasEnteredANumber(final int number) {
-		try {
-			ftMember.setWeight(number);
-			System.out.println("Set weight to " + number);
-		} catch (TibrvException e) {
-			System.err.println("Exception to set ft weight:");
-			handleFatalError(e);
-		}
+	protected void userHasEnteredANumber(final int number) throws TibrvException {
+		ftMember.setWeight(number);
+		System.out.println("Set weight to " + number);
 	}
 
-	public static void main(final String args[]) {
+	public static void main(final String args[]) throws Exception {
 		// Debug.diplayEnvInfo();
 
 		final ArgParser argParser = new ArgParser("TibRvListenFT");

--- a/src/ch/mtrail/tibrv/playground/ListenThreadJavaA.java
+++ b/src/ch/mtrail/tibrv/playground/ListenThreadJavaA.java
@@ -17,22 +17,17 @@ public class ListenThreadJavaA extends Abstract implements TibrvMsgCallback {
 
 	private TibrvQueueGroup group;
 
-	public ListenThreadJavaA(final String service, final String network, final String daemon, final String subject) {
+	public ListenThreadJavaA(final String service, final String network, final String daemon, final String subject)
+			throws TibrvException {
 		super(service, network, daemon);
 
-		try {
-			group = new TibrvQueueGroup();
-			final TibrvQueue queue = new TibrvQueue();
-			new TibrvListener(queue, this, transport, subject, null);
-			group.add(queue);
+		group = new TibrvQueueGroup();
+		final TibrvQueue queue = new TibrvQueue();
+		new TibrvListener(queue, this, transport, subject, null);
+		group.add(queue);
 
-			// Create error listener
-			group.add(createErrorHandler());
-		} catch (final TibrvException e) {
-			System.err.println("Failed to create listener:");
-			e.printStackTrace();
-			System.exit(1);
-		}
+		// Create error listener
+		group.add(createErrorHandler());
 	}
 
 	public void dispatch(final int threads) {
@@ -46,7 +41,7 @@ public class ListenThreadJavaA extends Abstract implements TibrvMsgCallback {
 						System.err.println("Exception dispatching default queue:");
 						e.printStackTrace();
 					}
-					
+
 					// IF shutdown == exit
 				}
 			});
@@ -56,16 +51,16 @@ public class ListenThreadJavaA extends Abstract implements TibrvMsgCallback {
 
 	@Override
 	public void onMsg(final TibrvListener listener, final TibrvMsg msg) {
-		System.out.println((new Date()).toString() + ": subject=" + msg.getSendSubject() + ", reply="
-				+ msg.getReplySubject() + ", message=" + msg.toString() + " THREAD: " + Thread.currentThread().getName());
-		System.out.flush();
-		
+		System.out.println(
+				(new Date()).toString() + ": subject=" + msg.getSendSubject() + ", reply=" + msg.getReplySubject()
+						+ ", message=" + msg.toString() + " THREAD: " + Thread.currentThread().getName());
+
 		msg.dispose();
-		
+
 		LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(500));
 	}
 
-	public static void main(final String args[]) {
+	public static void main(final String args[]) throws Exception {
 		final ArgParser argParser = new ArgParser("ListenThreadJavaA");
 		argParser.setRequiredParameter("threads");
 		argParser.setOptionalParameter("service", "network", "daemon");
@@ -76,9 +71,8 @@ public class ListenThreadJavaA extends Abstract implements TibrvMsgCallback {
 				argParser.getParameter("service"), //
 				argParser.getParameter("network"), //
 				argParser.getParameter("daemon"), //
-				argParser.getArgument("subject")
-				);
+				argParser.getArgument("subject"));
 
 		listen.dispatch(Integer.parseInt(argParser.getParameter("threads")));
-	}	
+	}
 }

--- a/src/ch/mtrail/tibrv/playground/ListenThreadRv.java
+++ b/src/ch/mtrail/tibrv/playground/ListenThreadRv.java
@@ -15,42 +15,37 @@ import com.tibco.tibrv.TibrvQueueGroup;
 public class ListenThreadRv extends Abstract implements TibrvMsgCallback {
 
 	public ListenThreadRv(final String service, final String network, final String daemon, final String subject,
-			final int threads) {
+			final int threads) throws TibrvException {
 		super(service, network, daemon);
 
-		try {
-			final TibrvQueueGroup group = new TibrvQueueGroup();
-			
-			// Create main listener.
-			final TibrvQueue queue = new TibrvQueue();
-			new TibrvListener(queue, this, transport, subject, null);
-			group.add(queue);
+		final TibrvQueueGroup group = new TibrvQueueGroup();
 
-			// Create error listener
-			group.add(createErrorHandler());
+		// Create main listener.
+		final TibrvQueue queue = new TibrvQueue();
+		new TibrvListener(queue, this, transport, subject, null);
+		group.add(queue);
 
-			for (int i = 0; i <= threads; i++) {
-				new TibrvDispatcher("Dispatcher-" + i, group);
-			}
-			System.out.println("Created " + threads + " threads on " + subject);
-		} catch (final TibrvException e) {
-			System.err.println("Failed to create listener:");
-			handleFatalError(e);
+		// Create error listener
+		group.add(createErrorHandler());
+
+		for (int i = 0; i <= threads; i++) {
+			new TibrvDispatcher("Dispatcher-" + i, group);
 		}
+		System.out.println("Created " + threads + " threads on " + subject);
 	}
 
 	@Override
 	public void onMsg(final TibrvListener listener, final TibrvMsg msg) {
-		System.out.println((new Date()).toString() + ": subject=" + msg.getSendSubject() + ", reply="
-				+ msg.getReplySubject() + ", message=" + msg.toString() + " THREAD: " + Thread.currentThread().getName());
-		System.out.flush();
+		System.out.println(
+				(new Date()).toString() + ": subject=" + msg.getSendSubject() + ", reply=" + msg.getReplySubject()
+						+ ", message=" + msg.toString() + " THREAD: " + Thread.currentThread().getName());
 
 		msg.dispose();
 
 		LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(500));
 	}
 
-	public static void main(final String args[]) {
+	public static void main(final String args[]) throws Exception {
 		// Debug.diplayEnvInfo();
 
 		final ArgParser argParser = new ArgParser("ListenThreadRv");

--- a/src/ch/mtrail/tibrv/playground/MonitorFT.java
+++ b/src/ch/mtrail/tibrv/playground/MonitorFT.java
@@ -10,20 +10,16 @@ public class MonitorFT extends Abstract implements TibrvFtMonitorCallback {
 	private double lostInterval = 4.8; // matches tibrvfttime
 	private static int oldNumActive = 0;
 
-	public MonitorFT(final String service, final String network, final String daemon, final String ftGroupName) {
+	public MonitorFT(final String service, final String network, final String daemon, final String ftGroupName)
+			throws TibrvException {
 		super(service, network, daemon);
 
 		// create listener using default queue
-		try {
-			new TibrvFtMonitor(Tibrv.defaultQueue(), this, transport, ftGroupName, lostInterval, null);
-			System.err.println("tibrvftmon: Waiting for group information... " + ftGroupName);
-		} catch (final TibrvException e) {
-			System.err.println("Failed to create listener:");
-			handleFatalError(e);
-		}
+		new TibrvFtMonitor(Tibrv.defaultQueue(), this, transport, ftGroupName, lostInterval, null);
+		System.err.println("tibrvftmon: Waiting for group information... " + ftGroupName);
 	}
 
-	public void dispatch() {
+	public void dispatch() throws TibrvException, InterruptedException {
 		dispatch(Tibrv.defaultQueue());
 	}
 
@@ -39,7 +35,7 @@ public class MonitorFT extends Abstract implements TibrvFtMonitorCallback {
 
 	}
 
-	public static void main(final String args[]) {
+	public static void main(final String args[]) throws Exception {
 		final ArgParser argParser = new ArgParser("TibRvListenFT");
 		argParser.setOptionalParameter("service", "network", "daemon", "groupName");
 		argParser.parse(args);

--- a/src/ch/mtrail/tibrv/playground/SendFiles.java
+++ b/src/ch/mtrail/tibrv/playground/SendFiles.java
@@ -17,14 +17,15 @@ public class SendFiles extends Abstract {
 	private final String subject;
 	private final static short fileTimeType = TibrvMsg.USER_FIRST + 1;
 
-	public SendFiles(final String service, final String network, final String daemon, final String subject) {
+	public SendFiles(final String service, final String network, final String daemon, final String subject)
+			throws TibrvException {
 		super(service, network, daemon);
 		this.subject = subject;
 
 		try {
 			final FileTimeEncoder fileTimeEncoder = new FileTimeEncoder();
 			TibrvMsg.setHandlers(fileTimeType, fileTimeEncoder, fileTimeEncoder);
-			
+
 			// Create error listener
 			final TibrvQueueGroup group = new TibrvQueueGroup();
 			group.add(createErrorHandler());
@@ -69,7 +70,7 @@ public class SendFiles extends Abstract {
 		msg.dispose();
 	}
 
-	public static void main(final String args[]) {
+	public static void main(final String args[]) throws Exception {
 		final ArgParser argParser = new ArgParser("SendFiles");
 		argParser.setOptionalParameter("service", "network", "daemon");
 		argParser.setRequiredParameter("folder");
@@ -82,22 +83,18 @@ public class SendFiles extends Abstract {
 				argParser.getParameter("daemon"), //
 				argParser.getArgument("subject"));
 
-		try {
-			final Path path = Paths.get(argParser.getParameter("folder"));
-			try (DirectoryStream<Path> ds = Files.newDirectoryStream(path)) {
-				for (final Path child : ds) {
-					if (Files.isRegularFile(child)) {
-						sender.send(child);
-						System.out.println("Submitted: " + child);
-					}
+		final Path path = Paths.get(argParser.getParameter("folder"));
+		try (DirectoryStream<Path> ds = Files.newDirectoryStream(path)) {
+			for (final Path child : ds) {
+				if (Files.isRegularFile(child)) {
+					sender.send(child);
+					System.out.println("Submitted: " + child);
 				}
 			}
-			
-			System.out.println("DONE");
-			sender.shutdown();
-		} catch (final TibrvException | IOException e) {
-			e.printStackTrace();
 		}
+
+		System.out.println("DONE");
+		sender.shutdown();
 
 	}
 

--- a/src/ch/mtrail/tibrv/playground/SendRequestReply.java
+++ b/src/ch/mtrail/tibrv/playground/SendRequestReply.java
@@ -12,43 +12,40 @@ public class SendRequestReply extends Abstract {
 	private final String subject;
 	private int msgSend = 0;
 
-	public SendRequestReply(final String service, final String network, final String daemon, final String subject) {
+	public SendRequestReply(final String service, final String network, final String daemon, final String subject)
+			throws TibrvException {
 		super(service, network, daemon);
 
 		this.subject = subject;
 	}
 
 	public void send(final String msgString) throws TibrvException {
-		try {
-			// Create the message
-			final TibrvMsg msg = new TibrvMsg();
-			msg.setSendSubject(subject);
+		// Create the message
+		final TibrvMsg msg = new TibrvMsg();
+		msg.setSendSubject(subject);
 
-			msg.add("DATA", msgString);
-			msg.add("INDEX", msgSend);
-			System.out.println((new Date()).toString() + " QUESTION: subject=" + msg.getSendSubject() + ", message="
-					+ msg.toString());
+		msg.add("DATA", msgString);
+		msg.add("INDEX", msgSend);
+		System.out.println(
+				(new Date()).toString() + " QUESTION: subject=" + msg.getSendSubject() + ", message=" + msg.toString());
 
-			// Timeout 30sec
-			final TibrvMsg replyMsg = transport.sendRequest(msg, 30);
+		// Timeout 30sec
+		final TibrvMsg replyMsg = transport.sendRequest(msg, 30);
 
-			msg.dispose();
+		msg.dispose();
 
-			if (replyMsg != null) {
-				System.out.println((new Date()).toString() + " REPLY: subject=" + replyMsg.getSendSubject() + ", message="
-						+ replyMsg.toString());
-	
-				replyMsg.dispose();
-			} else {
-				System.out.println((new Date()).toString() + " REPLY NO RECEIVED");
-			}
-			msgSend++;
-		} catch (final TibrvException e) {
-			handleFatalError(e);
+		if (replyMsg != null) {
+			System.out.println((new Date()).toString() + " REPLY: subject=" + replyMsg.getSendSubject() + ", message="
+					+ replyMsg.toString());
+
+			replyMsg.dispose();
+		} else {
+			System.out.println((new Date()).toString() + " REPLY NO RECEIVED");
 		}
+		msgSend++;
 	}
 
-	public static void main(final String args[]) {
+	public static void main(final String args[]) throws Exception {
 		final ArgParser argParser = new ArgParser("SendRequestReply");
 		argParser.setOptionalParameter("service", "network", "daemon", "interval");
 		argParser.setRequiredArg("msg", "subject");
@@ -60,23 +57,19 @@ public class SendRequestReply extends Abstract {
 				argParser.getParameter("daemon"), //
 				argParser.getArgument("subject"));
 
-		try {
-			System.out.println("Submitting: " + argParser.getArgument("msg"));
-			send.send(argParser.getArgument("msg"));
+		System.out.println("Submitting: " + argParser.getArgument("msg"));
+		send.send(argParser.getArgument("msg"));
 
-			final String intervalStr = argParser.getParameter("interval");
-			if (Objects.nonNull(intervalStr) && !intervalStr.isEmpty()) {
-				final int intervalMs = Integer.parseInt(intervalStr);
-				while (true) {
-					if (intervalMs > 0) {
-						// -interval 0 == hard core stress test
-						TimeUnit.MILLISECONDS.sleep(intervalMs);
-					}
-					send.send(argParser.getArgument("msg"));
+		final String intervalStr = argParser.getParameter("interval");
+		if (Objects.nonNull(intervalStr) && !intervalStr.isEmpty()) {
+			final int intervalMs = Integer.parseInt(intervalStr);
+			while (true) {
+				if (intervalMs > 0) {
+					// -interval 0 == hard core stress test
+					TimeUnit.MILLISECONDS.sleep(intervalMs);
 				}
+				send.send(argParser.getArgument("msg"));
 			}
-		} catch (TibrvException | InterruptedException e) {
-			e.printStackTrace();
 		}
 	}
 }


### PR DESCRIPTION
Exceptions können in main() weitergeworfen werden. Das führt dazu, dass
der Stacktrace auf System.err geschrieben wird und sich der Prozess mit
-1 beendet. Daher kann auf den eigenen Handling-Code verzichtet werden.

PrintStream.println() macht implizit einen flush(). Expliziter flush()
daher nicht notwendig.